### PR TITLE
feat/I31-33 :sparkle:  Implementar Sessão de votação

### DIFF
--- a/src/main/java/diegosneves/github/assembleiavota/config/handler/ControllerExceptionHandler.java
+++ b/src/main/java/diegosneves/github/assembleiavota/config/handler/ControllerExceptionHandler.java
@@ -2,9 +2,14 @@ package diegosneves.github.assembleiavota.config.handler;
 
 import diegosneves.github.assembleiavota.dto.ExceptionDTO;
 import diegosneves.github.assembleiavota.exceptions.ConstructorDefaultUndefinedException;
+import diegosneves.github.assembleiavota.exceptions.IllegalSessionArgumentException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicIntegerException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
 import diegosneves.github.assembleiavota.exceptions.MapperFailureException;
+import diegosneves.github.assembleiavota.exceptions.SessionCreateFailureException;
+import diegosneves.github.assembleiavota.exceptions.SessionNotFound;
+import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
 import diegosneves.github.assembleiavota.exceptions.UuidUtilsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -105,6 +110,69 @@ public class ControllerExceptionHandler {
     public ResponseEntity<ExceptionDTO> uuidUtilsRelatedFaileures(UuidUtilsException exception) {
         ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), UuidUtilsException.ERROR.getStatusCodeValue());
         return ResponseEntity.status(UuidUtilsException.ERROR.getHttpStatusCode()).body(dto);
+    }
+
+    /**
+     * Manipulador de exceções para falhas relacionadas ao tópico.
+     *
+     * @param exception uma exceção do tipo {@link TopicIdNotFoundException}, representando a situação onde um ID de tópico não foi encontrado.
+     * @return ResponseEntity, que encapsula tanto a resposta HTTP como o corpo do DTO de exceção ({@link ExceptionDTO}).
+     * A resposta HTTP contém o status do erro obtido da exceção TopicIdNotFoundException e o corpo contém a mensagem da exceção e o código do status.
+     */
+    @ExceptionHandler(TopicIdNotFoundException.class)
+    public ResponseEntity<ExceptionDTO> topicRelatedFaileures(TopicIdNotFoundException exception) {
+        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), TopicIdNotFoundException.ERROR.getStatusCodeValue());
+        return ResponseEntity.status(TopicIdNotFoundException.ERROR.getHttpStatusCode()).body(dto);
+    }
+
+    /**
+     * Manipulador de exceções para falhas relacionadas ao ID.
+     * Esse método é chamado quando uma exceção do tipo {@link InvalidIdException} é lançada.
+     *
+     * @param exception A exceção lançada que contém informações sobre a falha no ID.
+     * @return Uma resposta de entidade contendo o status HTTP correspondente à exceção e o dto contendo a mensagem da exceção.
+     */
+    @ExceptionHandler(InvalidIdException.class)
+    public ResponseEntity<ExceptionDTO> idRelatedFaileures(InvalidIdException exception) {
+        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), InvalidIdException.ERROR.getStatusCodeValue());
+        return ResponseEntity.status(InvalidIdException.ERROR.getHttpStatusCode()).body(dto);
+    }
+
+    /**
+     * Manipula exceções de falha na criação de sessões.
+     *
+     * @param exception Exceção de falha na criação de sessão que foi lançada.
+     * @return Um ResponseEntity que contém um DTO de exceção, com a mensagem de erro e o código de status da exceção.
+     */
+    @ExceptionHandler(SessionCreateFailureException.class)
+    public ResponseEntity<ExceptionDTO> sessionRelatedFaileures(SessionCreateFailureException exception) {
+        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), SessionCreateFailureException.ERROR.getStatusCodeValue());
+        return ResponseEntity.status(SessionCreateFailureException.ERROR.getHttpStatusCode()).body(dto);
+    }
+
+    /**
+     * Manipulador de exceções para situações onde a sessão não é encontrada.
+     *
+     * @param exception A exceção de Sessão Não Encontrada que foi lançada.
+     * @return Uma instância de ResponseEntity contendo os detalhes da exceção capturada,
+     * que inclui a mensagem da exceção e o código de status da HTTP Response.
+     */
+    @ExceptionHandler(SessionNotFound.class)
+    public ResponseEntity<ExceptionDTO> sessionRelatedFaileures(SessionNotFound exception) {
+        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), SessionNotFound.ERROR.getStatusCodeValue());
+        return ResponseEntity.status(SessionNotFound.ERROR.getHttpStatusCode()).body(dto);
+    }
+
+    /**
+     * Manipulador de exceções para lidar com argumentos de sessão inválidos.
+     *
+     * @param exception A exceção lançada por uma sessão ilegal ou argumentos inválidos.
+     * @return Uma resposta de entidade contendo a mensagem da exceção original e o código de status HTTP correspondente.
+     */
+    @ExceptionHandler(IllegalSessionArgumentException.class)
+    public ResponseEntity<ExceptionDTO> sessionRelatedFaileures(IllegalSessionArgumentException exception) {
+        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), IllegalSessionArgumentException.ERROR.getStatusCodeValue());
+        return ResponseEntity.status(IllegalSessionArgumentException.ERROR.getHttpStatusCode()).body(dto);
     }
 
 }

--- a/src/main/java/diegosneves/github/assembleiavota/config/web/OpenApiConfig.java
+++ b/src/main/java/diegosneves/github/assembleiavota/config/web/OpenApiConfig.java
@@ -58,8 +58,8 @@ public class OpenApiConfig {
      */
     private List<Tag> getTags() {
         return List.of(
-                new Tag().name("Associados").description("Funcionalidades direcionadas aos Associados"),
-                new Tag().name("Pautas").description("Funcionalidades direcionadas as Pautas"),
-                new Tag().name("Votos").description("Funcionalidades direcionadas aos Votos"));
+                new Tag().name("Sessão").description("Funcionalidades voltadas para as Sessões"),
+                new Tag().name("Pautas").description("Funcionalidades direcionadas às Pautas"),
+                new Tag().name("Votos").description("Funcionalidades relacionadas à coleta e contagem de Votos"));
     }
 }

--- a/src/main/java/diegosneves/github/assembleiavota/controllers/SessionController.java
+++ b/src/main/java/diegosneves/github/assembleiavota/controllers/SessionController.java
@@ -1,0 +1,21 @@
+package diegosneves.github.assembleiavota.controllers;
+
+import diegosneves.github.assembleiavota.controllers.contracts.SessionControllerContract;
+import diegosneves.github.assembleiavota.requests.StartSessionRequest;
+import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/session")
+public class SessionController implements SessionControllerContract {
+
+
+    @Override
+    public ResponseEntity<SessionCreatedResponse> startSession(StartSessionRequest request) {
+        SessionCreatedResponse response = new SessionCreatedResponse();
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/controllers/SessionController.java
+++ b/src/main/java/diegosneves/github/assembleiavota/controllers/SessionController.java
@@ -3,6 +3,8 @@ package diegosneves.github.assembleiavota.controllers;
 import diegosneves.github.assembleiavota.controllers.contracts.SessionControllerContract;
 import diegosneves.github.assembleiavota.requests.StartSessionRequest;
 import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+import diegosneves.github.assembleiavota.services.contract.SessionServiceContract;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,10 +14,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/session")
 public class SessionController implements SessionControllerContract {
 
+    private final SessionServiceContract sessionService;
+
+    @Autowired
+    public SessionController(SessionServiceContract sessionService) {
+        this.sessionService = sessionService;
+    }
 
     @Override
     public ResponseEntity<SessionCreatedResponse> startSession(StartSessionRequest request) {
-        SessionCreatedResponse response = new SessionCreatedResponse();
+        SessionCreatedResponse response = this.sessionService.startSession(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/diegosneves/github/assembleiavota/controllers/contracts/SessionControllerContract.java
+++ b/src/main/java/diegosneves/github/assembleiavota/controllers/contracts/SessionControllerContract.java
@@ -1,0 +1,41 @@
+package diegosneves.github.assembleiavota.controllers.contracts;
+
+import diegosneves.github.assembleiavota.requests.StartSessionRequest;
+import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * Interface {@link SessionControllerContract} representa o contrato para a gestão de sessões de votação.
+ *
+ * @author diegoneves
+ */
+public interface SessionControllerContract {
+
+    /**
+     * Inicia uma sessão de votação.
+     *
+     * @param request o objeto StartSessionRequest contendo o ID da pauta para a qual deseja-se iniciar a sessão de votação.
+     * @return um objeto ResponseEntity contendo um objeto {@link SessionCreatedResponse} que contém as informações da sessão criada.
+     */
+    @PostMapping(value = "/start", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "Inicia uma sessão de votação",
+            description = "Este endpoint é responsável por iniciar uma sessão de votação, requerendo o id da Pauta(Topic) como input",
+            tags = "Sessão"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Sessão de votação criada com sucesso!",
+                    content = @Content)
+    })
+    ResponseEntity<SessionCreatedResponse> startSession(@RequestBody StartSessionRequest request);
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/dto/TopicEntityDTO.java
+++ b/src/main/java/diegosneves/github/assembleiavota/dto/TopicEntityDTO.java
@@ -1,0 +1,20 @@
+package diegosneves.github.assembleiavota.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class TopicEntityDTO {
+
+    private String topicId;
+    private String title;
+    private String description;
+    private Integer votingSessionDuration;
+}

--- a/src/main/java/diegosneves/github/assembleiavota/enums/ExceptionHandler.java
+++ b/src/main/java/diegosneves/github/assembleiavota/enums/ExceptionHandler.java
@@ -15,7 +15,9 @@ public enum ExceptionHandler {
     CLASS_MAPPING_FAILURE("Falha ao tentar mapear a classe [ %s ].", HttpStatus.INTERNAL_SERVER_ERROR),
     TOPIC_ATTRIBUTE_INVALID("O campo [%s] não pode ser nulo ou vazio", HttpStatus.BAD_REQUEST),
     TOPIC_NON_NULL_INTEGER_ATTRIBUTE("A [%s] não pode ser nula", HttpStatus.BAD_REQUEST),
-    INVALID_UUID_FORMAT_MESSAGE("O ID [%s] precisa ser no formato UUID", HttpStatus.INTERNAL_SERVER_ERROR);
+    TOPIC_ID_NOT_FOUND("O ID %s do tópico não foi encontrado", HttpStatus.NOT_FOUND),
+    INVALID_ID_FORMAT("O ID [%s] precisa estar no formato UUID (Identificador Único Universal)", HttpStatus.BAD_REQUEST),
+    INVALID_UUID_FORMAT_MESSAGE("O ID [%s] precisa estar no formato UUID", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/diegosneves/github/assembleiavota/enums/ExceptionHandler.java
+++ b/src/main/java/diegosneves/github/assembleiavota/enums/ExceptionHandler.java
@@ -13,11 +13,14 @@ public enum ExceptionHandler {
 
     CONSTRUCTOR_DEFAULT_UNDEFINED("Classe [ %s ] deve declarar um construtor padrão.", HttpStatus.NOT_IMPLEMENTED),
     CLASS_MAPPING_FAILURE("Falha ao tentar mapear a classe [ %s ].", HttpStatus.INTERNAL_SERVER_ERROR),
-    TOPIC_ATTRIBUTE_INVALID("O campo [%s] não pode ser nulo ou vazio", HttpStatus.BAD_REQUEST),
-    TOPIC_NON_NULL_INTEGER_ATTRIBUTE("A [%s] não pode ser nula", HttpStatus.BAD_REQUEST),
+    TOPIC_ATTRIBUTE_INVALID("O campo %s não pode ser nulo ou vazio", HttpStatus.BAD_REQUEST),
+    TOPIC_NON_NULL_INTEGER_ATTRIBUTE("A %s não pode ser nula", HttpStatus.BAD_REQUEST),
     TOPIC_ID_NOT_FOUND("O ID %s do tópico não foi encontrado", HttpStatus.NOT_FOUND),
-    INVALID_ID_FORMAT("O ID [%s] precisa estar no formato UUID (Identificador Único Universal)", HttpStatus.BAD_REQUEST),
-    INVALID_UUID_FORMAT_MESSAGE("O ID [%s] precisa estar no formato UUID", HttpStatus.INTERNAL_SERVER_ERROR);
+    SESSION_ID_NOT_FOUND("O ID %s da Sessão não foi encontrado", HttpStatus.NOT_FOUND),
+    SESSION_ERROR_MESSAGE("Ocorreu um erro na Session devido ao seguinte motivo: %s", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_ID_FORMAT("O ID %s precisa estar no formato UUID (Identificador Único Universal)", HttpStatus.BAD_REQUEST),
+    FAILURE_CREATE_SESSION("O sistema falhou ao tentar estabelecer uma nova sessão de votação devido ao seguinte motivo: %s", HttpStatus.BAD_REQUEST),
+    INVALID_UUID_FORMAT_MESSAGE("O ID %s precisa estar no formato UUID", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/diegosneves/github/assembleiavota/exceptions/IllegalSessionArgumentException.java
+++ b/src/main/java/diegosneves/github/assembleiavota/exceptions/IllegalSessionArgumentException.java
@@ -1,0 +1,24 @@
+package diegosneves.github.assembleiavota.exceptions;
+
+import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+
+/**
+ * Classe IllegalSessionArgumentException.
+ * <p>
+ * Esta classe estende {@link RuntimeException} e é usada para tratar erros
+ * relacionados a argumentos de sessão inválidos em uma aplicação.
+ * <p>
+ * Ela usa um manipulador de exceções pré-definido (ERROR), que possui uma mensagem de erro
+ * predefinida para erros de sessão.
+ *
+ * @see RuntimeException
+ * @author diegoneves
+ */
+public class IllegalSessionArgumentException extends RuntimeException {
+
+    public static final ExceptionHandler ERROR = ExceptionHandler.SESSION_ERROR_MESSAGE;
+
+    public IllegalSessionArgumentException(String message) {
+        super(ERROR.getMessage(message));
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/exceptions/InvalidIdException.java
+++ b/src/main/java/diegosneves/github/assembleiavota/exceptions/InvalidIdException.java
@@ -8,11 +8,15 @@ import diegosneves.github.assembleiavota.enums.ExceptionHandler;
  * @see RuntimeException
  * @author diegoneves
  */
-public class InvalidTopicIdException extends RuntimeException {
+public class InvalidIdException extends RuntimeException {
 
     public static final ExceptionHandler ERROR = ExceptionHandler.INVALID_ID_FORMAT;
 
-    public InvalidTopicIdException(String message, Throwable e) {
+    public InvalidIdException(String message, Throwable e) {
         super(ERROR.getMessage(message), e);
+    }
+
+    public InvalidIdException(String message) {
+        super(ERROR.getMessage(message));
     }
 }

--- a/src/main/java/diegosneves/github/assembleiavota/exceptions/InvalidTopicIdException.java
+++ b/src/main/java/diegosneves/github/assembleiavota/exceptions/InvalidTopicIdException.java
@@ -1,0 +1,18 @@
+package diegosneves.github.assembleiavota.exceptions;
+
+import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+
+/**
+ * Representa uma exceção lançada quando um ID de tópico inválido é encontrado.
+ *
+ * @see RuntimeException
+ * @author diegoneves
+ */
+public class InvalidTopicIdException extends RuntimeException {
+
+    public static final ExceptionHandler ERROR = ExceptionHandler.INVALID_ID_FORMAT;
+
+    public InvalidTopicIdException(String message, Throwable e) {
+        super(ERROR.getMessage(message), e);
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/exceptions/SessionCreateFailureException.java
+++ b/src/main/java/diegosneves/github/assembleiavota/exceptions/SessionCreateFailureException.java
@@ -1,0 +1,18 @@
+package diegosneves.github.assembleiavota.exceptions;
+
+import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+
+/**
+ * Esta classe representa uma exceção personalizada que é lançada quando ocorre um erro ao criar uma sessão.
+ *
+ * @author diegoneves
+ * @see RuntimeException
+ */
+public class SessionCreateFailureException extends RuntimeException {
+
+    public static final ExceptionHandler ERROR = ExceptionHandler.FAILURE_CREATE_SESSION;
+
+    public SessionCreateFailureException(String message, Throwable e) {
+        super(ERROR.getMessage(message), e);
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/exceptions/SessionNotFound.java
+++ b/src/main/java/diegosneves/github/assembleiavota/exceptions/SessionNotFound.java
@@ -1,0 +1,13 @@
+package diegosneves.github.assembleiavota.exceptions;
+
+import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+
+public class SessionNotFound extends RuntimeException {
+
+    public static final ExceptionHandler ERROR = ExceptionHandler.SESSION_ID_NOT_FOUND;
+
+    public SessionNotFound(String message) {
+        super(ERROR.getMessage(message));
+    }
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/exceptions/TopicIdNotFoundException.java
+++ b/src/main/java/diegosneves/github/assembleiavota/exceptions/TopicIdNotFoundException.java
@@ -1,0 +1,18 @@
+package diegosneves.github.assembleiavota.exceptions;
+
+import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+
+/**
+ * Classe representando uma exceção personalizada para quando um tópico ID não é encontrado.
+ * Quando essa exceção é acionada, o manipulador de exceções padrão é definido para {@link ExceptionHandler TOPIC_ID_NOT_FOUND}.
+ *
+ * @author diegoneves
+ */
+public class TopicIdNotFoundException extends RuntimeException {
+
+    public static final ExceptionHandler ERROR = ExceptionHandler.TOPIC_ID_NOT_FOUND;
+
+    public TopicIdNotFoundException(String message) {
+        super(ERROR.getMessage(message));
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/factory/SessionEntityFactory.java
+++ b/src/main/java/diegosneves/github/assembleiavota/factory/SessionEntityFactory.java
@@ -1,0 +1,17 @@
+package diegosneves.github.assembleiavota.factory;
+
+import diegosneves.github.assembleiavota.models.SessionEntity;
+import diegosneves.github.assembleiavota.models.TopicEntity;
+import diegosneves.github.assembleiavota.utils.UuidUtils;
+
+import java.time.LocalDateTime;
+
+public class SessionEntityFactory {
+
+    private SessionEntityFactory() {}
+
+    public static SessionEntity create(TopicEntity topicEntity, LocalDateTime startTime) {
+        return new SessionEntity(UuidUtils.generateUuid(), topicEntity, true, startTime, startTime.plusMinutes(topicEntity.getVotingSessionDuration()));
+    }
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/mapper/BuilderMapper.java
+++ b/src/main/java/diegosneves/github/assembleiavota/mapper/BuilderMapper.java
@@ -1,6 +1,5 @@
 package diegosneves.github.assembleiavota.mapper;
 
-import diegosneves.github.assembleiavota.enums.ExceptionHandler;
 import diegosneves.github.assembleiavota.exceptions.ConstructorDefaultUndefinedException;
 import diegosneves.github.assembleiavota.exceptions.MapperFailureException;
 import lombok.extern.slf4j.Slf4j;
@@ -67,12 +66,12 @@ public class BuilderMapper {
      * @param strategy a estratégia a ser usada para construir o objeto de destino (opcional)
      * @return uma instância da classe destino com seus campos preenchidos
      */
-    public static <T, E> T mapTo(Class<T> destinationClass, E source, BuildingStrategy<T, E> strategy) {
+    public static <T, E> T mapTo(Class<T> destinationClass, E source, MapperStrategy<T, E> strategy) {
 		if (strategy == null) {
 			return BuilderMapper.mapTo(destinationClass, source);
 		}
 
-		return strategy.mapTo(source);
+		return strategy.mapFrom(source);
 	}
 
 }

--- a/src/main/java/diegosneves/github/assembleiavota/mapper/MapperStrategy.java
+++ b/src/main/java/diegosneves/github/assembleiavota/mapper/MapperStrategy.java
@@ -1,14 +1,14 @@
 package diegosneves.github.assembleiavota.mapper;
 
 /**
- * A interface {@link BuildingStrategy} define uma estratégia para executar operações de mapeamento de objetos.
+ * A interface {@link MapperStrategy} define uma estratégia para executar operações de mapeamento de objetos.
  *
  * @author diegosneves
  *
  * @param <T> o tipo da classe de destino
  * @param <E> o tipo do objeto de origem
  */
-public interface BuildingStrategy<T, E> {
+public interface MapperStrategy<T, E> {
 
     /**
      * Executa a estratégia para realizar uma operação de mapeamento entre objetos.
@@ -16,6 +16,6 @@ public interface BuildingStrategy<T, E> {
      * @param origem o objeto de origem que será convertido no objeto de destino
      * @return uma instância da classe de destino com seus campos preenchidos
      */
-    T mapTo(E origem);
+    T mapFrom(E origem);
 
 }

--- a/src/main/java/diegosneves/github/assembleiavota/mapper/SessionCreatedResponseMapper.java
+++ b/src/main/java/diegosneves/github/assembleiavota/mapper/SessionCreatedResponseMapper.java
@@ -1,0 +1,19 @@
+package diegosneves.github.assembleiavota.mapper;
+
+import diegosneves.github.assembleiavota.dto.TopicEntityDTO;
+import diegosneves.github.assembleiavota.models.SessionEntity;
+import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+
+public class SessionCreatedResponseMapper implements BuildingStrategy<SessionCreatedResponse, SessionEntity> {
+
+    @Override
+    public SessionCreatedResponse mapTo(SessionEntity origem) {
+        return SessionCreatedResponse.builder()
+                .sessionId(origem.getSessionId())
+                .topicEntityDTO(BuilderMapper.mapTo(TopicEntityDTO.class, origem.getTopic()))
+                .isOpen(origem.isOpen())
+                .startTime(origem.getStartTime())
+                .endTime(origem.getEndTime())
+                .build();
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/mapper/SessionCreatedResponseMapper.java
+++ b/src/main/java/diegosneves/github/assembleiavota/mapper/SessionCreatedResponseMapper.java
@@ -4,10 +4,10 @@ import diegosneves.github.assembleiavota.dto.TopicEntityDTO;
 import diegosneves.github.assembleiavota.models.SessionEntity;
 import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
 
-public class SessionCreatedResponseMapper implements BuildingStrategy<SessionCreatedResponse, SessionEntity> {
+public class SessionCreatedResponseMapper implements MapperStrategy<SessionCreatedResponse, SessionEntity> {
 
     @Override
-    public SessionCreatedResponse mapTo(SessionEntity origem) {
+    public SessionCreatedResponse mapFrom(SessionEntity origem) {
         return SessionCreatedResponse.builder()
                 .sessionId(origem.getSessionId())
                 .topicEntityDTO(BuilderMapper.mapTo(TopicEntityDTO.class, origem.getTopic()))

--- a/src/main/java/diegosneves/github/assembleiavota/models/SessionEntity.java
+++ b/src/main/java/diegosneves/github/assembleiavota/models/SessionEntity.java
@@ -1,0 +1,36 @@
+package diegosneves.github.assembleiavota.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "sessions")
+@Table(name = "sessions")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class SessionEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private String sessionId;
+    @ManyToOne
+    private TopicEntity topic;
+    private boolean isOpen;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+//    @OneToMany(mappedBy = "sessions")
+//    private List<Vote> votes;
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/repositories/SessionEntityRepository.java
+++ b/src/main/java/diegosneves/github/assembleiavota/repositories/SessionEntityRepository.java
@@ -1,0 +1,14 @@
+package diegosneves.github.assembleiavota.repositories;
+
+import diegosneves.github.assembleiavota.models.SessionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SessionEntityRepository extends JpaRepository<SessionEntity, String> {
+
+    Optional<SessionEntity> findBySessionId(String sessionId);
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/requests/StartSessionRequest.java
+++ b/src/main/java/diegosneves/github/assembleiavota/requests/StartSessionRequest.java
@@ -1,0 +1,14 @@
+package diegosneves.github.assembleiavota.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class StartSessionRequest {
+    private String topicId;
+}

--- a/src/main/java/diegosneves/github/assembleiavota/responses/SessionCreatedResponse.java
+++ b/src/main/java/diegosneves/github/assembleiavota/responses/SessionCreatedResponse.java
@@ -1,0 +1,26 @@
+package diegosneves.github.assembleiavota.responses;
+
+import diegosneves.github.assembleiavota.dto.TopicEntityDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class SessionCreatedResponse {
+
+    private String sessionId;
+    private TopicEntityDTO topicEntityDTO;
+    private boolean isOpen;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/services/SessionService.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/SessionService.java
@@ -1,0 +1,124 @@
+package diegosneves.github.assembleiavota.services;
+
+import diegosneves.github.assembleiavota.exceptions.IllegalSessionArgumentException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
+import diegosneves.github.assembleiavota.exceptions.SessionCreateFailureException;
+import diegosneves.github.assembleiavota.exceptions.SessionNotFound;
+import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
+import diegosneves.github.assembleiavota.exceptions.UuidUtilsException;
+import diegosneves.github.assembleiavota.factory.SessionEntityFactory;
+import diegosneves.github.assembleiavota.mapper.MapperStrategy;
+import diegosneves.github.assembleiavota.mapper.SessionCreatedResponseMapper;
+import diegosneves.github.assembleiavota.models.SessionEntity;
+import diegosneves.github.assembleiavota.models.TopicEntity;
+import diegosneves.github.assembleiavota.repositories.SessionEntityRepository;
+import diegosneves.github.assembleiavota.requests.StartSessionRequest;
+import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+import diegosneves.github.assembleiavota.services.contract.SessionServiceContract;
+import diegosneves.github.assembleiavota.services.contract.TopicServiceContract;
+import diegosneves.github.assembleiavota.utils.UuidUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static java.util.Objects.isNull;
+
+@Service
+@Slf4j
+public class SessionService implements SessionServiceContract {
+
+    public static final String NULL_TOPIC_ID = "ID da Pauta não pode ser nulo";
+    public static final String INVALID_TOPIC_ID = "ID da Pauta é inválida";
+    public static final String TOPIC_DOES_NOT_EXIST = "O ID da Pauta fornecido não foi encontrado no sistema. Certifique-se de que o ID está correto.";
+    public static final String SESSION_ID_CANNOT_BE_NULL = "da Sessão não pode ser nulo e";
+    public static final String SESSION_CANNOT_BE_NULL = "A Session não pode ser nula";
+
+    private final SessionEntityRepository repository;
+    private final TopicServiceContract topicService;
+
+    @Autowired
+    public SessionService(SessionEntityRepository repository, TopicServiceContract topicService) {
+        this.repository = repository;
+        this.topicService = topicService;
+    }
+
+    @Override
+    public SessionCreatedResponse startSession(StartSessionRequest request) throws SessionCreateFailureException {
+        TopicEntity topic = null;
+        try {
+            topic = this.topicService.getTopic(request.getTopicId());
+        } catch (InvalidIdException e) {
+            String message = request.getTopicId() == null ? NULL_TOPIC_ID : INVALID_TOPIC_ID;
+            log.error(SessionCreateFailureException.ERROR.getMessage(message), e);
+            throw new SessionCreateFailureException(message, e);
+        } catch (TopicIdNotFoundException e) {
+            log.error(SessionCreateFailureException.ERROR.getMessage(TOPIC_DOES_NOT_EXIST), e);
+            throw new SessionCreateFailureException(TOPIC_DOES_NOT_EXIST, e);
+        }
+        SessionEntity session = SessionEntityFactory.create(topic, LocalDateTime.now());
+        this.repository.save(session);
+        MapperStrategy<SessionCreatedResponse, SessionEntity> mapper = new SessionCreatedResponseMapper();
+        return mapper.mapFrom(session);
+    }
+
+    @Override
+    public SessionEntity getSession(String sessionId) throws SessionNotFound, InvalidIdException {
+        Optional<SessionEntity> optionalSession = this.repository.findBySessionId(validateSessionId(sessionId));
+        if (optionalSession.isPresent()) {
+            return optionalSession.get();
+        }
+        log.error(SessionNotFound.ERROR.getMessage(sessionId));
+        throw new SessionNotFound(sessionId);
+    }
+
+    /**
+     * Valida se a SessionId fornecida é válida. Ela não pode ser nula e deve ser um UUID válido.
+     *
+     * @param sessionId A identificação da sessão a ser validada.
+     * @return A session Id se ela for válida.
+     * @throws InvalidIdException se o sessionId for nulo ou se não for um UUID válido.
+     */
+    private static String validateSessionId(String sessionId) throws InvalidIdException {
+        if (sessionId == null) {
+            log.error(InvalidIdException.ERROR.getMessage(SESSION_ID_CANNOT_BE_NULL));
+            throw new InvalidIdException(SESSION_ID_CANNOT_BE_NULL);
+        }
+        try {
+            UuidUtils.isValidUUID(sessionId.trim());
+            return sessionId.trim();
+        } catch (UuidUtilsException e) {
+            log.error(InvalidIdException.ERROR.getMessage(sessionId), e);
+            throw new InvalidIdException(sessionId.trim(), e);
+        }
+    }
+
+    @Override
+    public boolean sessionIsOpen(SessionEntity session) throws IllegalSessionArgumentException {
+        sessionValidate(session);
+        boolean isOpen = LocalDateTime.now().isBefore(session.getEndTime());
+        session.setOpen(isOpen);
+        this.repository.save(session);
+        return isOpen;
+    }
+
+    /**
+     * Valida se a entidade da sessão fornecida é não-nula.
+     *
+     * @param session A entidade da sessão que será validada.
+     * @throws IllegalSessionArgumentException Se a entidade da sessão for nula.
+     */
+    private static void sessionValidate(SessionEntity session) throws IllegalSessionArgumentException {
+        if (isNull(session)) {
+            throw new IllegalSessionArgumentException(SESSION_CANNOT_BE_NULL);
+        }
+    }
+
+    @Override
+    public void updateSession(SessionEntity session) throws IllegalSessionArgumentException {
+        sessionValidate(session);
+        this.repository.save(session);
+    }
+}

--- a/src/main/java/diegosneves/github/assembleiavota/services/TopicService.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/TopicService.java
@@ -1,9 +1,8 @@
 package diegosneves.github.assembleiavota.services;
 
-import diegosneves.github.assembleiavota.enums.ExceptionHandler;
-import diegosneves.github.assembleiavota.exceptions.InvalidTopicIdException;
-import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicIntegerException;
+import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
 import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
 import diegosneves.github.assembleiavota.exceptions.UuidUtilsException;
 import diegosneves.github.assembleiavota.factory.TopicEntityFactory;
@@ -21,15 +20,17 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 
 import static diegosneves.github.assembleiavota.enums.ExceptionHandler.TOPIC_ID_NOT_FOUND;
+import static java.util.Objects.isNull;
 
 @Service
 @Slf4j
 public class TopicService implements TopicServiceContract {
 
-    private static final String TOPIC_TITLE = "Titulo";
-    private static final String TOPIC_DESCRIPTION = "Descrição";
-    private static final String VOTING_DURATION = "Duração";
-    private static final int DEFAULT_VALUE = 1;
+    public static final String TOPIC_TITLE = "Titulo";
+    public static final String TOPIC_DESCRIPTION = "Descrição";
+    public static final String VOTING_DURATION = "Duração";
+    public static final int DEFAULT_VALUE = 1;
+    public static final String TOPIC_ID_NULL_ERROR = "da Pauta não pode ser nulo e";
 
     private final TopicEntityRepository topicEntityRepository;
 
@@ -48,12 +49,12 @@ public class TopicService implements TopicServiceContract {
     }
 
     @Override
-    public TopicEntity getTopic(String topicId) throws InvalidTopicIdException, TopicIdNotFoundException {
-        Optional<TopicEntity> topicEntityOptional = topicEntityRepository.findByTopicId(validateTopicId(topicId));
+    public TopicEntity getTopic(String topicId) throws InvalidIdException, TopicIdNotFoundException {
+        Optional<TopicEntity> topicEntityOptional = this.topicEntityRepository.findByTopicId(validateTopicId(topicId));
         if (topicEntityOptional.isPresent()) {
             return topicEntityOptional.get();
         } else {
-            log.warn(TOPIC_ID_NOT_FOUND.getMessage(topicId));
+            log.error(TOPIC_ID_NOT_FOUND.getMessage(topicId));
             throw new TopicIdNotFoundException(topicId);
         }
     }
@@ -63,15 +64,19 @@ public class TopicService implements TopicServiceContract {
      *
      * @param topicId o {@link java.util.UUID ID} do tópico a ser validado
      * @return o {@link java.util.UUID ID} do tópico após ser validado e devidamente formatado
-     * @throws InvalidTopicIdException se o {@link java.util.UUID ID} do tópico não estiver no formato {@link java.util.UUID UUID}
+     * @throws InvalidIdException se o {@link java.util.UUID ID} do tópico não estiver no formato {@link java.util.UUID UUID}
      */
-    private static String validateTopicId(String topicId) throws InvalidTopicIdException {
+    private static String validateTopicId(String topicId) throws InvalidIdException {
+        if (isNull(topicId)) {
+            log.error(InvalidIdException.ERROR.getMessage(TOPIC_ID_NULL_ERROR));
+            throw new InvalidIdException(TOPIC_ID_NULL_ERROR);
+        }
         try {
             UuidUtils.isValidUUID(topicId.trim());
             return topicId.trim();
         } catch (UuidUtilsException e) {
             log.error(e.getMessage(), e);
-            throw new InvalidTopicIdException(topicId.trim(), e);
+            throw new InvalidIdException(topicId.trim(), e);
         }
     }
 

--- a/src/main/java/diegosneves/github/assembleiavota/services/TopicService.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/TopicService.java
@@ -1,7 +1,11 @@
 package diegosneves.github.assembleiavota.services;
 
+import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+import diegosneves.github.assembleiavota.exceptions.InvalidTopicIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicIntegerException;
+import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
+import diegosneves.github.assembleiavota.exceptions.UuidUtilsException;
 import diegosneves.github.assembleiavota.factory.TopicEntityFactory;
 import diegosneves.github.assembleiavota.mapper.BuilderMapper;
 import diegosneves.github.assembleiavota.models.TopicEntity;
@@ -9,9 +13,14 @@ import diegosneves.github.assembleiavota.repositories.TopicEntityRepository;
 import diegosneves.github.assembleiavota.requests.TopicRequest;
 import diegosneves.github.assembleiavota.responses.TopicCreatedResponse;
 import diegosneves.github.assembleiavota.services.contract.TopicServiceContract;
+import diegosneves.github.assembleiavota.utils.UuidUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static diegosneves.github.assembleiavota.enums.ExceptionHandler.TOPIC_ID_NOT_FOUND;
 
 @Service
 @Slf4j
@@ -38,6 +47,34 @@ public class TopicService implements TopicServiceContract {
         return BuilderMapper.mapTo(TopicCreatedResponse.class, topicEntity);
     }
 
+    @Override
+    public TopicEntity getTopic(String topicId) throws InvalidTopicIdException, TopicIdNotFoundException {
+        Optional<TopicEntity> topicEntityOptional = topicEntityRepository.findByTopicId(validateTopicId(topicId));
+        if (topicEntityOptional.isPresent()) {
+            return topicEntityOptional.get();
+        } else {
+            log.warn(TOPIC_ID_NOT_FOUND.getMessage(topicId));
+            throw new TopicIdNotFoundException(topicId);
+        }
+    }
+
+    /**
+     * Valida o {@link java.util.UUID ID} do tópico, que deve estar no formato {@link java.util.UUID UUID}.
+     *
+     * @param topicId o {@link java.util.UUID ID} do tópico a ser validado
+     * @return o {@link java.util.UUID ID} do tópico após ser validado e devidamente formatado
+     * @throws InvalidTopicIdException se o {@link java.util.UUID ID} do tópico não estiver no formato {@link java.util.UUID UUID}
+     */
+    private static String validateTopicId(String topicId) throws InvalidTopicIdException {
+        try {
+            UuidUtils.isValidUUID(topicId.trim());
+            return topicId.trim();
+        } catch (UuidUtilsException e) {
+            log.error(e.getMessage(), e);
+            throw new InvalidTopicIdException(topicId.trim(), e);
+        }
+    }
+
     /**
      * Este é um método para validar atributos de um tópico. Ele valida o título, a descrição e a duração da sessão de votação de um
      * tópico. Caso esses atributos estejam de acordo com as regras de validação, uma nova entidade de tópico é criada.
@@ -62,10 +99,10 @@ public class TopicService implements TopicServiceContract {
      * @param value O valor a ser validado.
      * @return Retorna o valor se este for válido.
      * @throws InvalidTopicStringAttributeException Se o valor for nulo, vazio ou em branco,
-     *                                 lança uma exceção com uma mensagem de erro, indicando qual campo é inválido.
+     *                                              lança uma exceção com uma mensagem de erro, indicando qual campo é inválido.
      */
     private static String validateTopicField(String field, String value) throws InvalidTopicStringAttributeException {
-        if (value == null || value.trim().isEmpty() || value.trim().isBlank()) {
+        if (value == null || value.isEmpty() || value.isBlank()) {
             log.error(InvalidTopicStringAttributeException.ERROR.getMessage(field));
             throw new InvalidTopicStringAttributeException(field);
         }

--- a/src/main/java/diegosneves/github/assembleiavota/services/contract/SessionServiceContract.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/contract/SessionServiceContract.java
@@ -1,0 +1,61 @@
+package diegosneves.github.assembleiavota.services.contract;
+
+import diegosneves.github.assembleiavota.exceptions.IllegalSessionArgumentException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
+import diegosneves.github.assembleiavota.exceptions.SessionCreateFailureException;
+import diegosneves.github.assembleiavota.exceptions.SessionNotFound;
+import diegosneves.github.assembleiavota.models.SessionEntity;
+import diegosneves.github.assembleiavota.requests.StartSessionRequest;
+import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+
+/**
+ * {@link SessionServiceContract} é uma interface que define o contrato para os serviços de sessão.
+ * Contêm a definição do método para iniciar uma nova sessão.
+ *
+ * @author diegoneves
+ */
+public interface SessionServiceContract {
+
+    /**
+     * Esse método é responsável por iniciar uma nova sessão baseada no objeto de solicitação fornecido.
+     *
+     * @param request objeto do tipo {@link StartSessionRequest} que contém as informações necessárias para iniciar uma nova sessão.
+     * @return retorna um objeto do tipo {@link SessionCreatedResponse} que indica a criação bem-sucedida da sessão e apresenta os detalhes da sessão recém-criada.
+     * @throws SessionCreateFailureException é lançada quando ocorre algum erro durante a criação da sessão.
+     */
+    SessionCreatedResponse startSession(StartSessionRequest request) throws SessionCreateFailureException;
+
+
+    /**
+     * Este método é utilizado para recuperar uma sessão a partir de um ID de sessão fornecido.
+     * Primeiramente, o método realiza a validação do ID da sessão e depois tenta recuperar a sessão do repositório.
+     * Caso a sessão não seja encontrada, um erro é registrado no log e uma exceção é lançada.
+     *
+     * @param sessionId ID da sessão a ser recuperada
+     * @return Retorna uma instância de {@link SessionEntity} que corresponde ao ID da sessão informado
+     * @throws SessionNotFound    Exceção lançada caso a sessão com o ID fornecido não seja encontrada
+     * @throws InvalidIdException Exceção lançada caso o ID da sessão fornecido não esteja em um formato válido
+     */
+    SessionEntity getSession(String sessionId) throws SessionNotFound, InvalidIdException;
+
+    /**
+     * Verifica se uma sessão está aberta.
+     * O método faz isso ao comparar se a hora atual é anterior ao horário de término da sessão.
+     * Após isso, o estado da sessão é atualizado com o resultado da verificação e a
+     * sessão modificada é salva no repositório.
+     *
+     * @param session A sessão a ser verificada. Não pode ser {@code null}.
+     * @return {@code true} se a sessão estiver aberta; {@code false} caso contrário.
+     * @throws IllegalSessionArgumentException Se a sessão passada como argumento for inválida.
+     */
+    boolean sessionIsOpen(SessionEntity session) throws IllegalSessionArgumentException;
+
+    /**
+     * Atualiza uma sessão existente na base de dados.
+     *
+     * @param session A sessão a ser atualizada.
+     * @throws IllegalSessionArgumentException se a sessão for inválida.
+     */
+    void updateSession(SessionEntity session) throws IllegalSessionArgumentException;
+
+}

--- a/src/main/java/diegosneves/github/assembleiavota/services/contract/TopicServiceContract.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/contract/TopicServiceContract.java
@@ -1,6 +1,9 @@
 package diegosneves.github.assembleiavota.services.contract;
 
+import diegosneves.github.assembleiavota.exceptions.InvalidTopicIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
+import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
+import diegosneves.github.assembleiavota.models.TopicEntity;
 import diegosneves.github.assembleiavota.requests.TopicRequest;
 import diegosneves.github.assembleiavota.responses.TopicCreatedResponse;
 
@@ -23,5 +26,15 @@ public interface TopicServiceContract {
      * @throws InvalidTopicStringAttributeException em caso de título inválido, descrição ou duração da sessão de votação.
      */
     TopicCreatedResponse createNewTopic(TopicRequest topicRequest) throws InvalidTopicStringAttributeException;
+
+    /**
+     * Retorna o tópico com base no {@link java.util.UUID ID} fornecido.
+     *
+     * @param topicId O identificador do tópico que será obtido.
+     * @return O objeto {@link TopicEntity} correspondente ao {@link java.util.UUID ID} do tópico fornecido.
+     * @throws InvalidTopicIdException  Se o {@link java.util.UUID ID} do tópico fornecido for inválido.
+     * @throws TopicIdNotFoundException Se o tópico com o {@link java.util.UUID ID} fornecido não for encontrado.
+     */
+    TopicEntity getTopic(String topicId) throws InvalidTopicIdException, TopicIdNotFoundException;
 
 }

--- a/src/main/java/diegosneves/github/assembleiavota/services/contract/TopicServiceContract.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/contract/TopicServiceContract.java
@@ -1,6 +1,6 @@
 package diegosneves.github.assembleiavota.services.contract;
 
-import diegosneves.github.assembleiavota.exceptions.InvalidTopicIdException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
 import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
 import diegosneves.github.assembleiavota.models.TopicEntity;
@@ -32,9 +32,9 @@ public interface TopicServiceContract {
      *
      * @param topicId O identificador do tópico que será obtido.
      * @return O objeto {@link TopicEntity} correspondente ao {@link java.util.UUID ID} do tópico fornecido.
-     * @throws InvalidTopicIdException  Se o {@link java.util.UUID ID} do tópico fornecido for inválido.
+     * @throws InvalidIdException  Se o {@link java.util.UUID ID} do tópico fornecido for inválido.
      * @throws TopicIdNotFoundException Se o tópico com o {@link java.util.UUID ID} fornecido não for encontrado.
      */
-    TopicEntity getTopic(String topicId) throws InvalidTopicIdException, TopicIdNotFoundException;
+    TopicEntity getTopic(String topicId) throws InvalidIdException, TopicIdNotFoundException;
 
 }

--- a/src/main/java/diegosneves/github/assembleiavota/services/contract/TopicServiceContract.java
+++ b/src/main/java/diegosneves/github/assembleiavota/services/contract/TopicServiceContract.java
@@ -5,6 +5,11 @@ import diegosneves.github.assembleiavota.requests.TopicRequest;
 import diegosneves.github.assembleiavota.responses.TopicCreatedResponse;
 
 
+/**
+ * Esta interface define o contrato para um Serviço de Tópicos. Ela fornece um método para criar um novo tópico.
+ *
+ * @author diegoneves
+ */
 public interface TopicServiceContract {
 
     /**

--- a/src/test/java/diegosneves/github/assembleiavota/services/SessionServiceTest.java
+++ b/src/test/java/diegosneves/github/assembleiavota/services/SessionServiceTest.java
@@ -1,0 +1,300 @@
+package diegosneves.github.assembleiavota.services;
+
+import diegosneves.github.assembleiavota.dto.TopicEntityDTO;
+import diegosneves.github.assembleiavota.exceptions.IllegalSessionArgumentException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
+import diegosneves.github.assembleiavota.exceptions.SessionCreateFailureException;
+import diegosneves.github.assembleiavota.exceptions.SessionNotFound;
+import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
+import diegosneves.github.assembleiavota.models.SessionEntity;
+import diegosneves.github.assembleiavota.models.TopicEntity;
+import diegosneves.github.assembleiavota.repositories.SessionEntityRepository;
+import diegosneves.github.assembleiavota.requests.StartSessionRequest;
+import diegosneves.github.assembleiavota.responses.SessionCreatedResponse;
+import diegosneves.github.assembleiavota.services.contract.TopicServiceContract;
+import diegosneves.github.assembleiavota.utils.UuidUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class SessionServiceTest {
+
+    private static final String TOPIC_UNIQUE_ID = "4658a51c-3840-453e-bc69-e2b4cff191a4";
+    private static final String UUID_SESSION_TEST = "1041148d-3cee-4d97-bafe-5aee1697eb78";
+    private static final String VOTACAO_TITLE = "Votacao";
+    private static final String DESCRIPTION = "Motivo";
+    private static final int VOTING_DURATION = 5;
+    private static final int YEAR = 2024;
+    private static final int MONTH = 4;
+    private static final int DAY = 28;
+    private static final int HOUR = 12;
+    private static final int MINUTE = 40;
+
+    @InjectMocks
+    private SessionService service;
+    @Mock
+    private SessionEntityRepository repository;
+    @Mock
+    private TopicServiceContract topicService;
+
+    @Captor
+    private ArgumentCaptor<SessionEntity> sessionCaptor;
+
+    private TopicEntity topic;
+    private TopicEntityDTO topicDTO;
+    private LocalDateTime startDateTime;
+
+
+    @BeforeEach
+    void setUp() {
+        this.topic = new TopicEntity(TOPIC_UNIQUE_ID, VOTACAO_TITLE, DESCRIPTION, VOTING_DURATION);
+        this.topicDTO = TopicEntityDTO.builder()
+                .topicId(TOPIC_UNIQUE_ID)
+                .title(VOTACAO_TITLE)
+                .description(DESCRIPTION)
+                .votingSessionDuration(VOTING_DURATION)
+                .build();
+        this.startDateTime = LocalDateTime.of(YEAR, MONTH, DAY, HOUR, MINUTE);
+    }
+
+    @Test
+    void shouldCreateSessionAndValidateAttributes() {
+        SessionCreatedResponse expect = SessionCreatedResponse.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topicEntityDTO(this.topicDTO)
+                .isOpen(true)
+                .startTime(this.startDateTime)
+                .endTime(this.startDateTime.plusMinutes(VOTING_DURATION))
+                .build();
+        SessionEntity sessionEntity = SessionEntity.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topic(this.topic)
+                .isOpen(true)
+                .startTime(this.startDateTime)
+                .endTime(this.startDateTime.plusMinutes(VOTING_DURATION))
+                .build();
+        StartSessionRequest request = new StartSessionRequest(TOPIC_UNIQUE_ID);
+
+        when(this.topicService.getTopic(TOPIC_UNIQUE_ID)).thenReturn(this.topic);
+        when(this.repository.save(any(SessionEntity.class))).thenReturn(sessionEntity);
+
+        SessionCreatedResponse actual = this.service.startSession(request);
+
+        verify(this.topicService, times(1)).getTopic(TOPIC_UNIQUE_ID);
+        verify(this.repository, times(1)).save(this.sessionCaptor.capture());
+
+        assertNotNull(actual);
+        SessionEntity captorValue = this.sessionCaptor.getValue();
+        assertTrue(UuidUtils.isValidUUID(actual.getSessionId()));
+        assertEquals(expect.getTopicEntityDTO().getTopicId(), actual.getTopicEntityDTO().getTopicId());
+        assertEquals(expect.isOpen(), actual.isOpen());
+        assertNotNull(actual.getStartTime());
+        assertNotNull(actual.getEndTime());
+        assertEquals(actual.getStartTime().plusMinutes(VOTING_DURATION), actual.getEndTime());
+        assertTrue(UuidUtils.isValidUUID(captorValue.getSessionId()));
+        assertEquals(this.topic, captorValue.getTopic());
+        assertEquals(captorValue.getStartTime().plusMinutes(VOTING_DURATION), captorValue.getEndTime());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStartingSessionWithNullTopicId() {
+        StartSessionRequest request = new StartSessionRequest(null);
+
+        when(this.topicService.getTopic(null)).thenThrow(new InvalidIdException(TopicService.TOPIC_ID_NULL_ERROR));
+
+        SessionCreateFailureException actual = assertThrows(SessionCreateFailureException.class, () -> this.service.startSession(request));
+
+        assertNotNull(actual);
+        assertEquals(SessionCreateFailureException.ERROR.getMessage(SessionService.NULL_TOPIC_ID), actual.getMessage());
+
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStartingSessionWithInvalidTopicId() {
+        String invalidTopicId = "234234243-sfdgsdf";
+        StartSessionRequest request = new StartSessionRequest(invalidTopicId);
+
+        when(this.topicService.getTopic(invalidTopicId)).thenThrow(new InvalidIdException(invalidTopicId));
+
+        SessionCreateFailureException actual = assertThrows(SessionCreateFailureException.class, () -> this.service.startSession(request));
+
+        assertNotNull(actual);
+        assertEquals(SessionCreateFailureException.ERROR.getMessage(SessionService.INVALID_TOPIC_ID), actual.getMessage());
+
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStartingSessionWithTopicIdNotExist() {
+        StartSessionRequest request = new StartSessionRequest(TOPIC_UNIQUE_ID);
+
+        when(this.topicService.getTopic(TOPIC_UNIQUE_ID)).thenThrow(new TopicIdNotFoundException(TOPIC_UNIQUE_ID));
+
+        SessionCreateFailureException actual = assertThrows(SessionCreateFailureException.class, () -> this.service.startSession(request));
+
+        assertNotNull(actual);
+        assertEquals(SessionCreateFailureException.ERROR.getMessage(SessionService.TOPIC_DOES_NOT_EXIST), actual.getMessage());
+
+    }
+
+    @Test
+    void shouldReturnSessionEntityWhenValidSessionIdIsGiven() {
+        SessionEntity sessionEntity = SessionEntity.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topic(this.topic)
+                .isOpen(true)
+                .startTime(this.startDateTime)
+                .endTime(this.startDateTime.plusMinutes(VOTING_DURATION))
+                .build();
+        when(this.repository.findBySessionId(UUID_SESSION_TEST)).thenReturn(Optional.ofNullable(sessionEntity));
+
+        SessionEntity actual = this.service.getSession(UUID_SESSION_TEST);
+
+        verify(this.repository, times(1)).findBySessionId(UUID_SESSION_TEST);
+
+        assertNotNull(actual);
+        assertEquals(sessionEntity, actual);
+    }
+
+    @Test
+    void shouldThrowSessionNotFoundWhenInvalidSessionIdIsGiven() {
+        when(this.repository.findBySessionId(UUID_SESSION_TEST)).thenReturn(Optional.empty());
+
+        SessionNotFound actual = assertThrows(SessionNotFound.class, () -> this.service.getSession(UUID_SESSION_TEST));
+
+        verify(this.repository, times(1)).findBySessionId(UUID_SESSION_TEST);
+
+        assertNotNull(actual);
+        assertEquals(SessionNotFound.ERROR.getMessage(UUID_SESSION_TEST), actual.getMessage());
+    }
+
+    @Test
+    void shouldThrowInvalidIdExceptionWhenNullSessionIdIsGiven() {
+
+        InvalidIdException actual = assertThrows(InvalidIdException.class, () -> this.service.getSession(null));
+
+        verify(this.repository, never()).findBySessionId(null);
+
+        assertNotNull(actual);
+        assertEquals(InvalidIdException.ERROR.getMessage(SessionService.SESSION_ID_CANNOT_BE_NULL), actual.getMessage());
+    }
+
+    @Test
+    void shouldThrowInvalidIdExceptionWhenInvalidSessionIdIsGiven() {
+        String sessionId = "id-invalid-123";
+
+        InvalidIdException actual = assertThrows(InvalidIdException.class, () -> this.service.getSession(sessionId));
+
+        verify(this.repository, never()).findBySessionId(sessionId);
+
+        assertNotNull(actual);
+        assertEquals(InvalidIdException.ERROR.getMessage(sessionId), actual.getMessage());
+    }
+
+    @Test
+    void shouldValidateIfSessionIsOpen() {
+        this.startDateTime = LocalDateTime.now();
+        SessionEntity sessionEntity = SessionEntity.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topic(this.topic)
+                .isOpen(true)
+                .startTime(this.startDateTime)
+                .endTime(this.startDateTime.plusMinutes(VOTING_DURATION))
+                .build();
+
+        boolean actual = this.service.sessionIsOpen(sessionEntity);
+
+        verify(this.repository, times(1)).save(this.sessionCaptor.capture());
+
+        assertTrue(actual);
+        assertTrue(this.sessionCaptor.getValue().isOpen());
+    }
+
+    @Test
+    void shouldCheckIfSessionIsOpenAndSaveTheState() {
+        this.startDateTime = LocalDateTime.now();
+        SessionEntity sessionEntity = SessionEntity.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topic(this.topic)
+                .isOpen(true)
+                .startTime(this.startDateTime)
+                .endTime(this.startDateTime)
+                .build();
+
+        boolean actual = this.service.sessionIsOpen(sessionEntity);
+
+        verify(this.repository, times(1)).save(this.sessionCaptor.capture());
+
+        assertFalse(actual);
+        assertFalse(this.sessionCaptor.getValue().isOpen());
+    }
+
+    @Test
+    void shouldValidateSessionIsConsideredClosedWhenEndTimeIsBeforeCurrentTimeDespiteIsOpenFlag() {
+        this.startDateTime = LocalDateTime.now();
+        SessionEntity sessionEntity = SessionEntity.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topic(this.topic)
+                .isOpen(true)
+                .startTime(this.startDateTime.plusMinutes(VOTING_DURATION))
+                .endTime(this.startDateTime)
+                .build();
+
+        boolean actual = this.service.sessionIsOpen(sessionEntity);
+
+        verify(this.repository, times(1)).save(this.sessionCaptor.capture());
+
+        assertFalse(actual);
+        assertFalse(this.sessionCaptor.getValue().isOpen());
+    }
+
+    @Test
+    void shouldThrowIllegalSessionArgumentExceptionWhenSessionIsNull() {
+        IllegalSessionArgumentException actual = assertThrows(IllegalSessionArgumentException.class, () -> this.service.sessionIsOpen(null));
+
+        verify(this.repository, never()).save(any(SessionEntity.class));
+
+        assertNotNull(actual);
+        assertEquals(IllegalSessionArgumentException.ERROR.getMessage(SessionService.SESSION_CANNOT_BE_NULL), actual.getMessage());
+    }
+
+    @Test
+    void shouldNotSaveNullSessionAndThrowIllegalSessionArgumentException() {
+        IllegalSessionArgumentException actual = assertThrows(IllegalSessionArgumentException.class, () -> this.service.updateSession(null));
+
+        verify(this.repository, never()).save(any(SessionEntity.class));
+
+        assertNotNull(actual);
+        assertEquals(IllegalSessionArgumentException.ERROR.getMessage(SessionService.SESSION_CANNOT_BE_NULL), actual.getMessage());
+    }
+
+    @Test
+    void should() {
+        SessionEntity sessionEntity = SessionEntity.builder()
+                .sessionId(UUID_SESSION_TEST)
+                .topic(this.topic)
+                .isOpen(true)
+                .startTime(this.startDateTime)
+                .endTime(this.startDateTime.plusMinutes(VOTING_DURATION))
+                .build();
+
+        this.service.updateSession(sessionEntity);
+        verify(this.repository, times(1)).save(sessionEntity);
+    }
+
+}

--- a/src/test/java/diegosneves/github/assembleiavota/services/TopicServiceTest.java
+++ b/src/test/java/diegosneves/github/assembleiavota/services/TopicServiceTest.java
@@ -1,8 +1,10 @@
 package diegosneves.github.assembleiavota.services;
 
 import diegosneves.github.assembleiavota.enums.ExceptionHandler;
+import diegosneves.github.assembleiavota.exceptions.InvalidTopicIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicIntegerException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
+import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
 import diegosneves.github.assembleiavota.models.TopicEntity;
 import diegosneves.github.assembleiavota.repositories.TopicEntityRepository;
 import diegosneves.github.assembleiavota.requests.TopicRequest;
@@ -16,6 +18,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -175,6 +179,62 @@ class TopicServiceTest {
 
         assertNotNull(actual);
         assertEquals(ExceptionHandler.TOPIC_NON_NULL_INTEGER_ATTRIBUTE.getMessage(VOTING_DURATION), actual.getMessage());
+    }
+
+    @Test
+    void shouldRetrieveValidTopicById() {
+        when(this.topicEntityRepository.findByTopicId(UUID_TEST)).thenReturn(Optional.ofNullable(this.topicEntity));
+
+        TopicEntity actual = this.topicService.getTopic(UUID_TEST);
+
+        verify(this.topicEntityRepository, times(1)).findByTopicId(UUID_TEST);
+
+        assertNotNull(actual);
+        assertEquals(UUID_TEST, actual.getTopicId());
+        assertEquals("Votacao", actual.getTitle());
+        assertEquals("Motivo", actual.getDescription());
+        assertEquals(2, actual.getVotingSessionDuration());
+        assertEquals(this.topicEntity, actual);
+    }
+
+    @Test
+    void shouldRetrieveValidTopicByIdWhenIdHasTrailingSpace() {
+        when(this.topicEntityRepository.findByTopicId(UUID_TEST)).thenReturn(Optional.ofNullable(this.topicEntity));
+
+        TopicEntity actual = this.topicService.getTopic(UUID_TEST + " ");
+
+        verify(this.topicEntityRepository, times(1)).findByTopicId(UUID_TEST);
+
+        assertNotNull(actual);
+        assertEquals(UUID_TEST, actual.getTopicId());
+        assertEquals("Votacao", actual.getTitle());
+        assertEquals("Motivo", actual.getDescription());
+        assertEquals(2, actual.getVotingSessionDuration());
+        assertEquals(this.topicEntity, actual);
+    }
+
+    @Test
+    void shouldThrowTopicIdNotFoundExceptionWhenTopicIdIsInvalid() {
+        when(this.topicEntityRepository.findByTopicId(UUID_TEST)).thenReturn(Optional.empty());
+
+        TopicIdNotFoundException actual = assertThrows(TopicIdNotFoundException.class, () -> this.topicService.getTopic(UUID_TEST));
+
+        verify(this.topicEntityRepository, times(1)).findByTopicId(UUID_TEST);
+
+        assertNotNull(actual);
+        assertEquals(TopicIdNotFoundException.ERROR.getMessage(UUID_TEST), actual.getMessage());
+    }
+
+    @Test
+    void shouldThrowInvalidTopicIdExceptionWhenTopicIdIsInvalid() {
+        String invalidTopicId = "invalidTopicId";
+
+        InvalidTopicIdException actual = assertThrows(InvalidTopicIdException.class, () -> this.topicService.getTopic(invalidTopicId));
+
+        verify(this.topicEntityRepository, never()).findByTopicId(invalidTopicId);
+
+        assertNotNull(actual);
+        assertEquals(InvalidTopicIdException.ERROR.getMessage(invalidTopicId), actual.getMessage());
     }
 
 }

--- a/src/test/java/diegosneves/github/assembleiavota/services/TopicServiceTest.java
+++ b/src/test/java/diegosneves/github/assembleiavota/services/TopicServiceTest.java
@@ -1,7 +1,7 @@
 package diegosneves.github.assembleiavota.services;
 
 import diegosneves.github.assembleiavota.enums.ExceptionHandler;
-import diegosneves.github.assembleiavota.exceptions.InvalidTopicIdException;
+import diegosneves.github.assembleiavota.exceptions.InvalidIdException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicIntegerException;
 import diegosneves.github.assembleiavota.exceptions.InvalidTopicStringAttributeException;
 import diegosneves.github.assembleiavota.exceptions.TopicIdNotFoundException;
@@ -36,10 +36,6 @@ import static org.mockito.Mockito.when;
 class TopicServiceTest {
 
     private static final String UUID_TEST = "4658a51c-3840-453e-bc69-e2b4cff191a4";
-    private static final String TOPIC_TITLE = "Titulo";
-    private static final String TOPIC_DESCRIPTION = "Descrição";
-    private static final String VOTING_DURATION = "Duração";
-    private static final int DEFAULT_VALUE = 1;
 
     @InjectMocks
     private TopicService topicService;
@@ -127,7 +123,7 @@ class TopicServiceTest {
         verify(this.topicEntityRepository, never()).save(any(TopicEntity.class));
 
         assertNotNull(actual);
-        assertEquals(ExceptionHandler.TOPIC_ATTRIBUTE_INVALID.getMessage(TOPIC_TITLE), actual.getMessage());
+        assertEquals(ExceptionHandler.TOPIC_ATTRIBUTE_INVALID.getMessage(TopicService.TOPIC_TITLE), actual.getMessage());
     }
 
     @Test
@@ -144,7 +140,7 @@ class TopicServiceTest {
         verify(this.topicEntityRepository, never()).save(any(TopicEntity.class));
 
         assertNotNull(actual);
-        assertEquals(ExceptionHandler.TOPIC_ATTRIBUTE_INVALID.getMessage(TOPIC_TITLE), actual.getMessage());
+        assertEquals(ExceptionHandler.TOPIC_ATTRIBUTE_INVALID.getMessage(TopicService.TOPIC_TITLE), actual.getMessage());
     }
 
     @Test
@@ -161,7 +157,7 @@ class TopicServiceTest {
         verify(this.topicEntityRepository, never()).save(any(TopicEntity.class));
 
         assertNotNull(actual);
-        assertEquals(ExceptionHandler.TOPIC_ATTRIBUTE_INVALID.getMessage(TOPIC_TITLE), actual.getMessage());
+        assertEquals(ExceptionHandler.TOPIC_ATTRIBUTE_INVALID.getMessage(TopicService.TOPIC_TITLE), actual.getMessage());
     }
 
     @Test
@@ -178,7 +174,7 @@ class TopicServiceTest {
         verify(this.topicEntityRepository, never()).save(any(TopicEntity.class));
 
         assertNotNull(actual);
-        assertEquals(ExceptionHandler.TOPIC_NON_NULL_INTEGER_ATTRIBUTE.getMessage(VOTING_DURATION), actual.getMessage());
+        assertEquals(ExceptionHandler.TOPIC_NON_NULL_INTEGER_ATTRIBUTE.getMessage(TopicService.VOTING_DURATION), actual.getMessage());
     }
 
     @Test
@@ -229,12 +225,23 @@ class TopicServiceTest {
     void shouldThrowInvalidTopicIdExceptionWhenTopicIdIsInvalid() {
         String invalidTopicId = "invalidTopicId";
 
-        InvalidTopicIdException actual = assertThrows(InvalidTopicIdException.class, () -> this.topicService.getTopic(invalidTopicId));
+        InvalidIdException actual = assertThrows(InvalidIdException.class, () -> this.topicService.getTopic(invalidTopicId));
 
         verify(this.topicEntityRepository, never()).findByTopicId(invalidTopicId);
 
         assertNotNull(actual);
-        assertEquals(InvalidTopicIdException.ERROR.getMessage(invalidTopicId), actual.getMessage());
+        assertEquals(InvalidIdException.ERROR.getMessage(invalidTopicId), actual.getMessage());
+    }
+
+    @Test
+    void shouldThrowInvalidTopicIdExceptionWhenTopicIdIsNull() {
+
+        InvalidIdException actual = assertThrows(InvalidIdException.class, () -> this.topicService.getTopic(null));
+
+        verify(this.topicEntityRepository, never()).findByTopicId(any());
+
+        assertNotNull(actual);
+        assertEquals(InvalidIdException.ERROR.getMessage(TopicService.TOPIC_ID_NULL_ERROR), actual.getMessage());
     }
 
 }


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [x] Feature
- [ ] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição
- **Atualização da Configuração do OpenApi**
  - Este commit modifica os nomes e descrições das tags na configuração do OpenApi.
  
- **Modificação de Tags**
  - A tag "Associados" foi substituída por "Sessão". 
  - Foi atualizada a descrição voltada para as funcionalidades das sessões.
  
- **Alteração na Descrição de Votos**
  - A descrição da tag "Votos" foi alterada para enfatizar a coleta e contagem de votos.

---

- **feat/I31-33 :sparkles: Adição de Estrutura para Gestão de Sessões de Votação**
  - Este commit cria as classes e interfaces necessárias para o gerenciamento de sessões de votação.
  
- **Implementação de Componentes**
  - Mapeadores
  - Fábricas
  - Entidades
  - DTOs
  - Requests
  - Responses
  - Controllers
  - Contratos de Controllers
  
Todos esses componentes estão relacionados ao gerenciamento das sessões.

---

- **feat/I31-33 :sparkles: Adição do SessionEntityRepository e atualização do SessionController e TopicServiceContract**

  - Nova adição de arquivo: **SessionEntityRepository**. Esse novo arquivo foi adicionado para gerenciar a entidade Session no banco de dados. 

  - Atualização em arquivo: **SessionController**. Foi atualizado para usar o novo serviço de sessão e encapsular a implementação do serviço. 

  - Atualização em arquivo: **TopicServiceContract**. Também foi atualizado, com comentários javadoc adicionados para explicar seu propósito e funcionalidade.

---

- **feat/I31-33 :white_check_mark: Adiciona funcionalidade para buscar tópico por ID**

  - Introdução de uma nova função: **'getTopic'**. Esta função permite buscar um tópico dado seu identificador.

  - Tratamento para casos em que o ID é inválido ou não encontrado.

  - Adição de testes correspondentes para cada cenário.

---

- **feat/I31-33 :sparkles: Adiciona exceções personalizadas para IDs de tópicos**

  - Criação de duas exceções personalizadas: **InvalidTopicIdException** e **TopicIdNotFoundException**. Estas foram criadas para lidar com problemas específicos relacionados aos IDs de tópicos.

  - Adição de mensagens correspondentes no enum: **ExceptionHandler**.

---

- **feat/I31-33 :recycle: Renomear "BuildingStrategy" para "MapperStrategy" e atualizar métodos relacionados**

  - Refatoração do código: A interface **BuildingStrategy** foi renomeada para **MapperStrategy**. Esta mudança de nomenclatura torna a designação mais adequada ao papel de mapeamento realizado.

  - Atualização de métodos: Os métodos em diferentes classes que se referem a essa estratégia também foram atualizados para seguir a nova nomenclatura.

---

- **feat/I31-33 :sparkles: Adicionar exceções personalizadas e manipuladores de exceção**

  - Adição de novas exceções personalizadas: Foram criadas para lidar com argumentos inválidos de sessão, falha na criação de sessão e sessão não encontrada.

  - Alteração de nomenclatura: O nome da exceção **InvalidTopicIdException** foi alterado para **InvalidIdException**.

  - Adição de manipuladores de exceção: Correspondentes adicionados ao **ControllerExceptionHandler** com o propósito de lidar com as novas exceções e fornecer feedback de erro apropriado para o usuário.

  - Atualizações em mensagens de erro: Alterações foram realizadas nas mensagens de erro no enum **ExceptionHandler**.

---

- **feat/I31-33 :recycle: Refatora exceção InvalidTopicId para InvalidIdException**

  - Substituição da exceção: A exceção **InvalidTopicIdException** foi substituída por **InvalidIdException** para tornar a aplicação mais genérica.

  - Adição de verificação: Foi adicionada uma verificação para garantir que o ID do tópico não seja nulo, melhorando a robustez do código.

  - Mudanças relacionadas: Alterações correspondentes foram realizadas em **TopicService** e **TopicServiceTest**.

---

- **feat/I31-33 :sparkles: Adiciona implementação e testes para o serviço de Sessão**

  - Adição da implementação: O serviço **SessionService** e seu respectivo contrato **SessionServiceContract** foram adicionados ao projeto.

  - Inclusão de testes unitários: Foram incluídos para garantir o correto funcionamento do **SessionService**.

  - Responsabilidades do **SessionService**: Este serviço é responsável por controlar as operações relacionadas às sessões de votação, como iniciar uma nova sessão, recuperar uma sessão existente e verificar se uma sessão está aberta.

---
